### PR TITLE
Gian

### DIFF
--- a/Capstone/app/src/main/java/com/example/capstone/TeacherProfileConfirmationFragment.java
+++ b/Capstone/app/src/main/java/com/example/capstone/TeacherProfileConfirmationFragment.java
@@ -174,11 +174,13 @@ public class TeacherProfileConfirmationFragment extends Fragment implements OnMa
     }
 
     public void locationFromName (String userInputName) {
+        // Defining search scope/context
+        String searchContext = " Vancouver, BC, Canada";
         if (userInputName.equals("")) {
             userInputName = "4700 Kingsway, Burnaby, BC V5H 4N2"; // Placeholder address, for testing purposes.
         }
         try {
-            addresses = geocoder.getFromLocationName(userInputName, 1);
+            addresses = geocoder.getFromLocationName(userInputName + searchContext, 1);
             updateUI();
         } catch (IOException e) {
             e.printStackTrace();
@@ -214,6 +216,8 @@ public class TeacherProfileConfirmationFragment extends Fragment implements OnMa
         params.put("price", priceParam);
         params.put("message", inputMessage);
 
+        Log.d("POST_Map", params.toString());
+
         try {
             APICaller.Post("class", params, new APICallBack() {
                 @Override
@@ -234,9 +238,6 @@ public class TeacherProfileConfirmationFragment extends Fragment implements OnMa
         }
 
         alert.show();
-        Log.d("POST_Map", params.toString());
-
-
     }
 
     @Override

--- a/Capstone/app/src/main/java/com/example/capstone/TeacherProfileConfirmationFragment.java
+++ b/Capstone/app/src/main/java/com/example/capstone/TeacherProfileConfirmationFragment.java
@@ -87,7 +87,7 @@ public class TeacherProfileConfirmationFragment extends Fragment implements OnMa
         selectedTeacher = ((MainActivity)getActivity()).getTeacher();
         selectedAvailability = ((MainActivity)getActivity()).getAvailability();
         // Checking if selectedClassType is not null here.
-        selectedClassType = ((MainActivity)getActivity()).getClassTypes().size() == 0 ? "" : ((MainActivity)getActivity()).getClassTypes().get(0);
+        selectedClassType = (((MainActivity)getActivity()).getClassTypes() == null || ((MainActivity)getActivity()).getClassTypes().size() == 0) ? "" : ((MainActivity)getActivity()).getClassTypes().get(0);
 
         Log.d("POST_Date", selectedAvailability.getDate());
         Log.d("POST_TimeSlots", selectedAvailability.getTimeSlots().toString());
@@ -191,7 +191,7 @@ public class TeacherProfileConfirmationFragment extends Fragment implements OnMa
         // If the parameter type is String, it will default to the empty string so there is no need to check it here.
         // Note: selectedClassType has already been checked.
         String teacherIdParam = selectedTeacher.getId() == 0 ? "" : Integer.toString(selectedTeacher.getId());
-        String timeSlotParam = selectedAvailability.getTimeSlots().size() == 0 ? "" : selectedAvailability.getTimeSlots().get(0);
+        String timeSlotParam = (selectedAvailability.getTimeSlots() == null || selectedAvailability.getTimeSlots().size() == 0) ? "" : selectedAvailability.getTimeSlots().get(0);
         String locationLatParam = "", locationLongParam = "";
         if (locationCoordinates.length == 2) {
             locationLatParam = locationCoordinates[0].toString();


### PR DESCRIPTION
The second commit adds a "search scope/context" in the form of a string (" Vancouver, BC, Canada") appended to the user's input on the search input field.

@jeanpierobom noticed that when geocoding fails (i.e. when Google Map's API cannot find any coordinates associated with the user's input) there is no visual feedback and if the user simply hits the "Confirm" button a class will be scheduled without a proper location.

This update is not a solution to the lack of an error message/feedback (though this can be easily solved with a warning popup) but rather it just tries to make this scenario unlikely.